### PR TITLE
added loadApiJson for non UI generated images

### DIFF
--- a/web/load_workflow.js
+++ b/web/load_workflow.js
@@ -159,6 +159,8 @@ async function handleFile(origHandleFile, file, ...args)
   const metadata = await getMetadata(file);
   if (metadata && metadata.workflow)
     app.loadGraphData(metadata.workflow);
+  if (metadata && metadata.prompt)
+    app.loadApiJson(metadata.prompt);
   else
     return origHandleFile.call(this, file, ...args);
 }

--- a/web/load_workflow.js
+++ b/web/load_workflow.js
@@ -159,7 +159,7 @@ async function handleFile(origHandleFile, file, ...args)
   const metadata = await getMetadata(file);
   if (metadata && metadata.workflow)
     app.loadGraphData(metadata.workflow);
-  if (metadata && metadata.prompt)
+  else if (metadata && metadata.prompt)
     app.loadApiJson(metadata.prompt);
   else
     return origHandleFile.call(this, file, ...args);


### PR DESCRIPTION
when you generate an image with the node via the api the metadata.workflow is not populated, so I added the loadApiJson for those cases